### PR TITLE
Replace package `flag` with `github.com/spf13/pflag` to support POSIX/GNU style flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,8 @@ module github.com/ngaut/sqltop
 go 1.13
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/spf13/pflag v1.0.3
-	github.com/stretchr/testify v1.4.0 // indirect
 	google.golang.org/appengine v1.6.1 // indirect
-	gopkg.in/gizak/termui.v1 v1.0.0-20151021151108-e62b5929642a
 )

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gizak/termui/v3 v3.1.0
 	github.com/go-sql-driver/mysql v1.4.1
-	github.com/mattn/go-runewidth v0.0.2 // indirect
-	github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d // indirect
+	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0 // indirect
 	google.golang.org/appengine v1.6.1 // indirect
 	gopkg.in/gizak/termui.v1 v1.0.0-20151021151108-e62b5929642a

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"flag"
+	"database/sql"
 	"fmt"
 	"log"
 	"os"
@@ -10,8 +10,7 @@ import (
 	"time"
 
 	ui "github.com/gizak/termui/v3"
-
-	"database/sql"
+	flag "github.com/spf13/pflag"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -19,11 +18,11 @@ import (
 const version = "0.1"
 
 var (
-	host  = flag.String("h", "127.0.0.1", "host")
-	pwd   = flag.String("p", "", "pwd")
-	user  = flag.String("u", "root", "user")
-	port  = flag.Int("P", 3306, "port")
-	count = flag.Int("n", 50, "Number of process to show")
+	host  = flag.StringP("host", "h", "127.0.0.1", "host")
+	pwd   = flag.StringP("password", "p", "", "pwd")
+	user  = flag.StringP("user", "u", "root", "user")
+	port  = flag.IntP("port", "P", 3306, "port")
+	count = flag.IntP("count", "n", 50, "Number of process to show")
 )
 
 func InitDB() error {


### PR DESCRIPTION
Support command flags like below:
```sh
./sqltop --host=127.0.0.1 -P3306 -uuser -ppwd
```
POSIX/GNU style flags are more user-friendly since we can copy parameters directly from mysql management scripts